### PR TITLE
Replace some links to ftp server with ECCO Drive

### DIFF
--- a/products/all/index.php
+++ b/products/all/index.php
@@ -42,17 +42,17 @@ EOF;
 							<tr>
 								<th class="text-left" rowspan="2"><a href="/products/latest/">ECCO-V4r3</a></th>
 								<td><a href="https://dspace.mit.edu/handle/1721.1/110380" target="_blank" rel="noopener noreferrer">I.D.</a></td>
-								<td><a href="ftp://ecco.jpl.nasa.gov/Version4/Release3/" target="_blank" rel="noopener noreferrer">Release 3</a></td>
+								<td><a href="https://ecco.jpl.nasa.gov/drive/files/Version4/Release3/" target="_blank" rel="noopener noreferrer">Release 3</a></td>
 								<td>1992-2015</td>
 								<td>LLC90</td>
 								<td>50</td>
 								<td>adjoint</td>
 								<td>4</td>
-								<td><a href="ftp://ecco.jpl.nasa.gov/Version4/Release3/doc/" target="_blank" rel="noopener noreferrer">Documentation</a></td>
+								<td><a href="https://ecco.jpl.nasa.gov/drive/files/Version4/Release3/doc/" target="_blank" rel="noopener noreferrer">Documentation</a></td>
 							</tr>
 							<tr>
 								<td>&gt;</td>
-								<td><a href=" ftp://ecco.jpl.nasa.gov/Version4/Release3/interp_monthly/" target="_blank" rel="noopener noreferrer">Interpolated climatology</a></td>
+								<td><a href="https://ecco.jpl.nasa.gov/drive/files/Version4/Release3/interp_monthly/" target="_blank" rel="noopener noreferrer">Interpolated climatology</a></td>
 								<td>1992-2015</td>
 								<td>1/2 deg.</td>
 								<td>50</td>
@@ -233,7 +233,7 @@ EOF;
 							<tr>
 								<th class="text-left">ECCO2</th>
 								<td><a href="http://dx.doi.org/10.1029/2005EO090002" target="_blank" rel="noopener noreferrer">I.D.</a></td>
-								<td><a href="ftp://ecco.jpl.nasa.gov/ECCO2/cube92_latlon_quart_90S90N/" target="_blank" rel="noopener noreferrer">Cube 92</a></td>
+								<td><a href="https://ecco.jpl.nasa.gov/drive/files/ECCO2/cube92_latlon_quart_90S90N/" target="_blank" rel="noopener noreferrer">Cube 92</a></td>
 								<td>1992-present</td>
 								<td> CS510 </td>
 								<td>50</td>
@@ -255,7 +255,7 @@ EOF;
 							<tr>
                                                                 <th class="text-left"><a href="/ecco-jpl/">ECCO-KFS</a></th>
 								<td><a href="http://dx.doi.org/10.1175/1520-0493(2002)130<1370:APKFAS>2.0.CO;2" target="_blank" rel="noopener noreferrer">I.D.</a></td>
-								<td><a href="ftp://ecco.jpl.nasa.gov/NearRealTime/" target="_blank" rel="noopener noreferrer">Run 80h</a></td>
+								<td><a href="https://ecco.jpl.nasa.gov/drive/files/NearRealTime/" target="_blank" rel="noopener noreferrer">Run 80h</a></td>
 								<td>1993-present</td>
 								<td>0.3 to 1 deg. </td>
 								<td>46</td>

--- a/products/latest/index.php
+++ b/products/latest/index.php
@@ -31,8 +31,9 @@ EOF;
 ECCO's latest ocean state estimate. This product is an updated edition to that described by Forget et al. (2015, Geosci. Model Dev.). Version 4 is the first multi-decadal ECCO estimate that is truly global, including the Arctic Ocean. The Release 3 edition includes improvements in time-period (1992-2015), model (e.g., sea-ice), observations (e.g., GRACE, Aquarius), and constraints (e.g., correlated errors).
 </p>
 						<p>[<i>Image at right</i>] Speed (cm/s) of 1992-2015 time-mean current at 5m depth. The figure combines into a global image, V4r3's thirteen tiles, each a 90-by-90 grid delineated by white lines.</p>
+                                                <p><strong>Due to NASA's mandate to disallow the use of the ftp protocol for data access, ECCO's anonymous ftp server ftp://ecco.jpl.nasa.gov/ has been replaced by ECCO Drive. ECCO Drive https://ecco.jpl.nasa.gov/drive/files/ offers a familiar interface for users to browse and download data through their browser. It also allows users to access data via a command line interface, enabling scripted data extracting. Each user must first register for an <a href="https://urs.earthdata.nasa.gov/documentation">Earthdata account</a> at https://urs.earthdata.nasa.gov/users/new in order to access the ECCO products.</strong></p>
 						<br />
-						<p><strong><a href="ftp://ecco.jpl.nasa.gov/Version4/Release3/" class="button white">Download Product</a></strong></p>
+						<p><strong><a href="https://ecco.jpl.nasa.gov/drive/files/Version4/Release3/" class="button white">Download Product</a></strong></p>
 						<p><strong><a href="https://web.corral.tacc.utexas.edu/OceanProjects/ECCO/ECCOv4/Release3/" class="button white">Download Product (mirror)</a></strong></p>
 					</div>
 					<div class="grid-cell grid--1of3 margin-20">


### PR DESCRIPTION
Replace some links originally pointing to the ECCO ftp server (ftp://ecco.jpl.nasa.gov) with ECCO Drive (https://ecco.jpl.nasa.gov/drive/files/).