### PR TITLE
revamped research presentation pages

### DIFF
--- a/includes/header.inc.php
+++ b/includes/header.inc.php
@@ -64,7 +64,7 @@
               <div class='side_nav'>
                 <ul>
                     <li><a href="/" title="Visit the ECCO home page.">Home</a></li>
-                    <li><a href="/about/" title="Learn more about ECCO by visiting this page.">About</a></li>
+                    <li><a href="/news/" title="Read news articles about the ECCO Mission by visiting this page.">News</a></li>
                     <li>
                       <a href="/products/all/" title="Learn more about ECCO's products.">Products</a>
                       <ul class="subnav">
@@ -94,7 +94,7 @@
                         <li><a href="/research/presentations/" title="ECCO Research Presentations">Presentations</a></li>
                       </ul>
                     </li>
-                    <li><a href="/news/" title="Read news articles about the ECCO Mission by visiting this page.">News</a></li>
+                    <li><a href="/about/" title="Learn more about ECCO by visiting this page.">About</a></li>
                 </ul>
               </div>
               <a class='visuallyhidden focusable' href='#main'>Skip Navigation</a>

--- a/index.php
+++ b/index.php
@@ -407,16 +407,11 @@ Commented out: Ichiro Fukumori 12/05/19 END
 											2019 Town Hall at the AGU Fall Meeting (12/09 12:30-13:30)
 										</div>
 										<div class='article_teaser_body'>
-											<p>The ECCO consortium hosted a town hall at the 2019 AGU Fall Meeting to introduce the latest global ocean and sea-ice state estimate Version 4 Release 4 (ECCO V4r4).
-											</p>
+											<p>The ECCO consortium hosted a town hall at the 2019 AGU Fall Meeting to introduce the latest global ocean and sea-ice state estimate Version 4 Release 4 (ECCO V4r4).</p>
 											
-											<p>Release 4 of the ECCO state estimate synthesizes nearly all extant in-situ and remotely-sensed ocean and sea-ice data covering the period 1992–2017, with a nominal 1-degree horizontal resolution configuration of the MIT general circulation model (MITgcm) over the entire globe.
-											</p>
+											<p>Release 4 of the ECCO state estimate synthesizes nearly all extant in-situ and remotely-sensed ocean and sea-ice data covering the period 1992–2017, with a nominal 1-degree horizontal resolution configuration of the MIT general circulation model (MITgcm) over the entire globe.</p>
 
-                                            <p>
-                                            	<a href="https://drive.google.com/file/d/1FcCKC8EOKZ5H_76cUu_Irkfq7lQjlKSb/view?usp=sharing" target="_blank" style="color:red" rel="noopener noreferrer"> Download a copy of the presentation here!</a><img alt="powerpoint presentation icon" title="powerpoint presentation icon" src="/assets/images/icons/powerpoint_icon.png">
-                                            </p>
-
+											<p>Download the presentation here: <a href="https://drive.google.com/file/d/1FcCKC8EOKZ5H_76cUu_Irkfq7lQjlKSb/view?usp=sharing" style="color:blue" target="_blank" rel="noopener noreferrer">as Powerpoint</a> or <a href="https://drive.google.com/file/d/15luafygxoaKilxsYjkQwv3cZGQy2JU4c/view?usp=sharing" style="color:blue" target="_blank" rel="noopener noreferrer">as PDF</a>.</p>
 										</div>
 									</div>
 								</div>

--- a/news/index.php
+++ b/news/index.php
@@ -27,31 +27,51 @@
 <p>The <a href="https://ecco.jpl.nasa.gov/drive/files/Version4/Release4/" target="blank">new release 4</a> extends the Version 4 estimate using additional observations. The product also incorporates improvements in modeling and estimation. A <a href="https://ecco.jpl.nasa.gov/drive/files/Version4/Release4/doc/v4r4_synopsis.pdf" target="blank">summary document</a> describes details of the changes. In addition to standard monthly mean fields, the release now includes daily mean estimates for studies of wider range of ocean variability. As in previous releases, tools are avalaible for <a href="https://ecco.jpl.nasa.gov/drive/files/Version4/Release3/doc/evaluating_budgets_in_eccov4r3.pdf" target="blank">evaluating property budgets</a> and <a href="https://ecco.jpl.nasa.gov/drive/files/Version4/Release3/doc/v4r3_reproduction_howto.pdf" target="blank">rerunning the model to generate additional fields</a> </p>
 
 <!---------------------------------------------------------------------->
+<!-- IAN FENTY 2019-12-17  -->
+
 <hr />
-<h4>ECCO Town Hall at 2018 AGU Fall Meeting</h4>
+<h4>ECCO Town Hall at 2019 AGU Fall Meeting</h4>
 
-<p><b>Synopsis:</b> The ECCO consortium will host a town hall at the AGU Fall Meeting in Washington, DC.  We will introduce the latest global ocean and sea-ice state estimate Version 4 Release 3 (ECCO v4 Release 3).  Release 3 of the ECCO state estimate synthesizes nearly all extant in-situ and remotely-sensed ocean and sea-ice data covering the period 1992 – 2015, with a nominal 1-degree horizontal resolution configuration of the MIT general circulation model (MITgcm) over the entire globe.</p>
+<p>The ECCO consortium hosted a town hall at the 2019 AGU Fall Meeting to introduce the latest global ocean and sea-ice state estimate Version 4 Release 4 (ECCO V4r4).</p>
+											
+<p>Release 4 of the ECCO state estimate synthesizes nearly all extant in-situ and remotely-sensed ocean and sea-ice data covering the period 1992–2017, with a nominal 1-degree horizontal resolution configuration of the MIT general circulation model (MITgcm) over the entire globe.</p>
 
-<p>By design, ECCO state estimates conserve heat, salt, volume and momentum—a virtue that is critical for analyzing causal mechanisms of ocean variability, and detecting climate signals that are small residuals of large regional anomalies. Instructional material will be provided for analyzing different aspects of the state estimate, including budget analysis, along with instructions for downloading and running the ocean model to recreate the solution. In addition, a selection of recent science applications will be highlighted. Members of the ECCO Group will be available to answer questions and provide guidance on utilizing the products.</p>
-
-<b>Date & Time:</b> Monday, 10 December 2018: 12:30 - 13:30 <br/>
-<b>Location: </b><a class='detail_link' href='https://www.marriott.com/hotel-meetings/wasco-marriott-marquis-washington-dc/modules/meetings/meeting-event-space.mi'>Marriott Marquis</a>, 901 Massachusetts Avenue NW, Washington DC 20001<br>Room: Liberty L<br />
-</p>
+<p>Download the presentation here: <a class='detail_link' href="https://drive.google.com/file/d/1FcCKC8EOKZ5H_76cUu_Irkfq7lQjlKSb/view?usp=sharing" target="_blank" rel="noopener noreferrer">as Powerpoint</a> or <a class='detail_link' href="https://drive.google.com/open?id=15luafygxoaKilxsYjkQwv3cZGQy2JU4c" target="_blank" rel="noopener noreferrer">as PDF</a>.</p>
 
 <!---------------------------------------------------------------------->
+<!-- IAN FENTY 2019-12-17  -->
 <hr />
 <h4>ECCO Summer School 2019</h4>
 
-<p><b>Synopsis:</b> The Consortium for "Estimating the Circulation and Climate of the Ocean" (ECCO) will host a summer school for graduate students and early career scientists on global ocean state estimation in support of climate research. The school introduces the tools and mathematics of ocean state and parameter estimation and their application to ocean science through a mix of foundational lectures, hands-on tutorials, and projects. In doing so, the school aims to help nurture the next generation of oceanographers and climate scientists in the subject matter so that they may utilize the ECCO products and underlying modeling/estimation tools most effectively to further advance the state-of-the-art in ocean state estimation and ocean science. </p>
+<p>The ECCO consortium hosted a two-week summer school for graduate students and early career scientists on global ocean state estimation in support of climate research. The school, held 19-31 May 2019 at Friday Harbor Laboratories in Friday Harbor WA, introduced tools and mathematics of ocean state and parameter estimation and their application to ocean science through a mix of foundational lectures, hands-on tutorials, and projects.</p>
 
-<p><b>Topics covered:</b> Data assimilation (global & regional); state & parameter estimation; adjoint method; sensitivity analysis; algorithmic differentiation; ocean modeling; ocean dynamics and variability; global ocean observing system; physics of sea level; sea ice physics; ice sheet-ocean interactions; ice shelf dynamics; ocean tides; cyberinfrastructure & data analytics </p>
+<p>Information about the school, including the lectures, can be found at 
+<a class='detail_link' href='https://www.eccosummerschool.org'>https://www.eccosummerschool.org</a>
 
-<b>Dates:</b> May 19–31, 2019 <br /><br />
-<b>Location:</b> Friday Harbor Laboratories, University of Washington, Friday Harbor, WA <br /><br />
-<b>Application Deadline:</b> December 17, 2018 <br /><br />
 
-For more information, confirmed lecturers, and <b>how to apply</b>, please visit: <a href="https://www.eccosummerschool.org">https://www.eccosummerschool.org</a><br>
-</p>
+<!---------------------------------------------------------------------->
+<!-- IAN FENTY 2019-12-17  -->
+<hr />
+<h4>ECCO Town Hall at 2018 AGU Fall Meeting</h4>
+
+The ECCO consortium hosted a town hall at the 2018 AGU Fall Meeting in Washington, DC.  We introduced the latest global ocean and sea-ice state estimate Version 4 Release 3 (ECCO v4 Release 3).  Release 3 of the ECCO state estimate synthesizes nearly all extant in-situ and remotely-sensed ocean and sea-ice data covering the period 1992 – 2015, with a nominal 1-degree horizontal resolution configuration of the MIT general circulation model (MITgcm) over the entire globe.</p>
+
+<p>By design, ECCO state estimates conserve heat, salt, volume and momentum—a virtue that is critical for analyzing causal mechanisms of ocean variability, and detecting climate signals that are small residuals of large regional anomalies. Instructional material will be provided for analyzing different aspects of the state estimate, including budget analysis, along with instructions for downloading and running the ocean model to recreate the solution. In addition, a selection of recent science applications will be highlighted. Members of the ECCO Group will be available to answer questions and provide guidance on utilizing the products.</p>
+
+<p>Download the presentation here: <a class='detail_link' href="https://drive.google.com/file/d/1RYsPR4Nq832JNJNg6al3GkXYEj28C64n/view?usp=sharing" target="_blank" rel="noopener noreferrer">as Powerpoint</a> or <a class='detail_link' href="https://drive.google.com/open?id=1Nc1dDBlhrgOGvwjmkwRKY8krEWdze12B" target="_blank" rel="noopener noreferrer">as PDF</a>.</p>
+
+<!---------------------------------------------------------------------->
+<!-- IAN FENTY 2019-12-17  -->
+<hr />
+<h4>ECCO Tutorial at Ocean Sciences 2018</h4>
+
+<p>The ECCO consortium hosted a town hall at the 2018 AGU Oceans Sciences Meeting in Portland, OR.  We introduced the latest global ocean and sea-ice state estimate Version 4 Release 3 (ECCO v4 Release 3).  Release 3 of the ECCO state estimate synthesizes nearly all extant in-situ and remotely-sensed ocean and sea-ice data covering the period 1992 – 2015, with a nominal 1-degree horizontal resolution configuration of the MIT general circulation model (MITgcm) over the entire globe.</p>
+
+<p>Tutorial attendees were shown how to obtain the latest ECCO ocean state estimates and provided instructions for calculating heat, salt, and volume budget analyses, comparing the state estimates against observational data, and for re-running the open-source ECCO model for additional custom investigations.  Python and Matlab computational libraries and tutorials that facilitate ECCO analyses will be introduced.</p>
+
+<p>Finally, attendees were provided salient examples of diverse science applications that make use of ECCO ocean state estimates and the adjoint of the ECCO numerical model drawn from the recent literature.</p>
+
+<p>Download the presentation here: <a class='detail_link' href="https://drive.google.com/file/d/1IJBscHc3vVYYL6uCoZqCUseooTVt81NZ/view?usp=sharing" target="_blank" rel="noopener noreferrer">as Powerpoint</a> or <a class='detail_link' href="https://drive.google.com/open?id=1hqLBVCZmXg1dwT1CwxD1I4bV7RRhPZzj" target="_blank" rel="noopener noreferrer">as PDF</a>.</p>
 
 <!---------------------------------------------------------------------->
 <hr />

--- a/research/presentations/archives/index.php
+++ b/research/presentations/archives/index.php
@@ -17,17 +17,16 @@ EOF;
 			<header id='page_header'>
 				<h1 class='article_title'>Archived Presentations</h1>
 			</header>
+			<p>Table of Contents</p>
 			<div class='wysiwyg_content'>
 				<ul class="bullet_list indent">
-					<li><a href="#posters">Meeting Posters</a></li>
-					<li><a href="#posters_jpl">ECCO-JPL Group: Meeting Posters</a></li>
-					<?php /*
-						<li><a href="#posters_sio">ECCO-SIO Group: Meeting Posters</a></li>
-					*/ ?>
+					<li><a href="#woce2002/">2002 WOCE Final Conference</a></li>
+					<li><a href="#igarss2002">2002 IGARSS </a></li>
+					<li><a href="#godae2002">2002 GODAE </a></li>
+					<li><a href="#jason2002">2002 Jason-1 </a></li>					
 				</ul>
-				<hr />
-
-				<h3 class="content_title named-anchor" id="posters">MEETING POSTERS</h3>
+				<br><br>
+				<h2 class="content_title named-anchor" id="woce2002">WOCE Final Conference</h2>
 				<p>ECCO Abstracts submitted to the WOCE Final Conference:</p>
 				<ul class="bullet_list">
 					<li>
@@ -160,80 +159,35 @@ EOF;
 						<a href="../pdfs/woce_posters/woce_uwe_poster.pdf" target="_blank" rel="noopener noreferrer">(PDF of poster) <img src="/assets/images/icons/acrobatlogo.gif" class="img--initial" /></a>
 					</li>
 				</ul>
-				<hr />
-				<h3 class="content_title named-anchor" id="posters_jpl">JPL GROUP MEETING POSTERS</h3>
+				<br><br>
+				<h2 class="content_title named-anchor" id="igarss2002">2002 IGARSS</h2>
 				<section class="grid_gallery list_view">
-					<p><strong>WOCE 2002</strong></p>
 					<ul class="articles">
 						<li class="slide">
-							<a href="../pdfs/woce_posters/woce_ecco2.pdf">
+							<a href="../pdfs/jpl_posters/tmp.pdf">
 								<div class="image_and_description_container">
 									<div class="img">
-										<img class="thumb" src="/assets/images/research/presentations/woce_ecco2.jpg" alt="presentation screenshot">
+										<img class="thumb" src="/assets/images/research/presentations/tmp.jpg" alt="presentation screenshot">
 									</div>
 									<div class="list_text_content">
 										<div class="article_teaser_body">
 											<p>
-												Seasonal-to-Interannual Variability of the Ocean During WOCE, Estimated by the ECCO Routine Global Ocean Data Assimilation System<br />
-												WOCE and Beyond<br />
-												San Antonio, Texas<br />
-												November 18-22, 2002<br />
+												Mapping and Pseudo-Inverse Algorithms for Data Assimilation<br />
+												International Geoscience & Remote Sensing Symposium<br />
+												Toronto, Canada<br />
+												June 24-28, 2002
 											</p>
 											<p>
-												Overview of ECCO near real-time data assimilation system and examples of its applications. The system consists of a hierarchy of assimilation methods that assimilate satellite sea surface height and in situ temperature profiles. Anayses are sensible and provide a means to study ocean circulation. Results are also used in geodetic studies.
+												Summary: Reduced-state Kalman filters require interpolation operators from the reduced state to the fine grid and pseudo-inverse operators that map the fine grid back to the reduced state. This poster investigates a variety of approaches to computing the pseudoinverse and evaluates the mapping performance of eleven interpolation kernels.
 											</p>
 										</div>
 									</div>
 								</div>
 							</a>
 						</li>
-						<li class="slide">
-							<a href="../pdfs/woce_posters/woce_tracer_new.pdf">
-								<div class="image_and_description_container">
-									<div class="img">
-										<img class="thumb" src="/assets/images/research/presentations/woce_tracer_new.jpg" alt="presentation screenshot">
-									</div>
-									<div class="list_text_content">
-										<div class="article_teaser_body">
-											<p>
-												An Open-Circuit and a Short-Circuit in the Pacific Ocean Subtropical-Tropical Exchange<br />
-												WOCE and Beyond<br />
-												San Antonio, Texas<br />
-												November 18-22, 2002
-											</p>
-											<p>
-												Pathway of subtropical-tropical exchange in the Pacific Ocean is analyzed using a simulated passive tracer and its adjoint. Intra-seasonal variability short-circuits the meridional exchange. Contrary to the so-called "Subtropical Cell", the pathway of the exchange is an open circuit and does not close.
-											</p>
-										</div>
-									</div>
-								</div>
-							</a>
-						</li>
-						<li class="slide">
-							<a href="../pdfs/woce_posters/MLheat.pdf">
-								<div class="image_and_description_container">
-									<div class="img">
-										<img class="thumb" src="/assets/images/research/presentations/MLheat.jpg" alt="presentation screenshot">
-									</div>
-									<div class="list_text_content">
-										<div class="article_teaser_body">
-											<p>
-												Interannual variation of mixed-layer heat balance: contrasting different climate phenomena and the roles of linear vs. nonlinear effects<br />
-												WOCE and Beyond<br />
-												San Antonio, Texas<br />
-												November 18-22, 2002
-											</p>
-											<p>
-												Interannual variation of mixed-layer heat budget associated with the climate events of El Nino, IOD, and PDO phase switch during the period of 1997-2000 are examined using ECCO assimilation product. Similarity and difference in interannual mixed-layer heat balance for these events are discussed. The role of nonlinear vs. linear advective tendencies are addressed.
-											</p>
-										</div>
-									</div>
-								</div>
-							</a>
-						</li>
-					</ul>
-
-					<p><strong>Jason-1 2002</strong></p>
+					</ul>				
+					<br><br>
+					<h2 class="content_title named-anchor" id="jason2002">2002 Jason-1</h2>
 					<ul class="articles">
 						<li class="slide">
 							<a href="../pdfs/jpl_posters/jason_021021.pdf">
@@ -258,34 +212,8 @@ EOF;
 							</a>
 						</li>
 					</ul>
-
-					<p><strong>IGARSS 2002</strong></p>
-					<ul class="articles">
-						<li class="slide">
-							<a href="../pdfs/jpl_posters/tmp.pdf">
-								<div class="image_and_description_container">
-									<div class="img">
-										<img class="thumb" src="/assets/images/research/presentations/tmp.jpg" alt="presentation screenshot">
-									</div>
-									<div class="list_text_content">
-										<div class="article_teaser_body">
-											<p>
-												Mapping and Pseudo-Inverse Algorithms for Data Assimilation<br />
-												International Geoscience & Remote Sensing Symposium<br />
-												Toronto, Canada<br />
-												June 24-28, 2002
-											</p>
-											<p>
-												Summary: Reduced-state Kalman filters require interpolation operators from the reduced state to the fine grid and pseudo-inverse operators that map the fine grid back to the reduced state. This poster investigates a variety of approaches to computing the pseudoinverse and evaluates the mapping performance of eleven interpolation kernels.
-											</p>
-										</div>
-									</div>
-								</div>
-							</a>
-						</li>
-					</ul>
-
-					<p><strong>GODAE 2002</strong></p>
+					<br><br>
+					<h2 class="content_title named-anchor" id="godae2002">2002 GODAE</h2>
 					<ul class="articles">
 						<li class="slide">
 							<a href="../pdfs/jpl_posters/ecco2.pdf">
@@ -376,8 +304,8 @@ EOF;
 							</a>
 						</li>
 					</ul>
-
-					<p><strong>Jason-1 2002</strong></p>
+					<br><br>
+					<h2 class="content_title named-anchor" id="jason2002">2002 Jason-1</h2>
 					<ul class="articles">
 						<li class="slide">
 							<a href="../pdfs/jpl_posters/tracer.pdf">

--- a/research/presentations/index.php
+++ b/research/presentations/index.php
@@ -18,11 +18,21 @@ EOF;
 				<h1 class='article_title'>Presentations</h1>
 			</header>
 			<div class='wysiwyg_content'>
+				<h3><a href="recent/">Recent Presentations</a></h3>
 				<ul class="bullet_list indent">
-					<li><a href="recent/">Recent Presentations</a></li>
-					<li><a href="archives/">Archived Presentations</a></li>
+					<li><a href="recent/">2019 AGU Fall Meeting</a></li>
+					<li><a href="recent/">2019 ECCO Summer School</a></li>										
+					<li><a href="recent/">2018 AGU Fall Meeting</a></li>
+					<li><a href="recent/">2018 AGU Ocean Sciences Meeting</a></li>
+					<li><a href="recent/">2017 ECCO Meeting</a></li>					
 				</ul>
-
+				<h3><a href="archives/">Archived Presentations</a></h3>
+				<ul class="bullet_list indent">
+					<li><a href="recent/">2002 WOCE Final Conference</a></li>
+					<li><a href="recent/">2002 IGARSS </a></li>
+					<li><a href="recent/">2002 GODAE </a></li>
+					<li><a href="recent/">2002 Jason-1 </a></li>
+				</ul>
 			</div><!-- //.wysiwyg_content -->
 		</div><!-- //.grid_layout -->
 	</section><!-- //.content_page -->

--- a/research/presentations/recent/index.php
+++ b/research/presentations/recent/index.php
@@ -17,15 +17,57 @@ EOF;
 			<header id='page_header'>
 				<h1 class='article_title'>Recent Presentations</h1>
 			</header>
-			<hr />
+			<p>Table of Contents</p>
 			<div class='wysiwyg_content'>
-				<h3 class="content_title named-anchor" id="posters">2017 ECCO Meeting</h3>
-				<p>Download the presentations from the November 6-8 meeting held at Caltech</p>
-
-				<h2 class="content_title named-anchor" id="posters">Latest ECCO Products</h2>
+				<ul class="bullet_list indent">
+					<li><a href="#2019FallMtg">2019 AGU Fall Meeting</a></li>
+					<li><a href="#2019SS">2019 ECCO Summer School</a></li>
+					<li><a href="#2018FallMtg">2018 AGU Fall Meeting</a></li>
+					<li><a href="#2018OSMtg">2018 AGU Ocean Sciences Meeting</a></li>
+					<li><a href="#2017ECCOMtg">2017 ECCO Meeting</a></li>
+				</ul>
+				<br><br>
+				<h2 class="content_title named-anchor" id="2019FallMtg">2019 AGU Fall Meeting</h2>
 				<ul class="bullet_list">
 					<li>
-						<a href="../pdfs/06_1030_Campin_ecco_17_jnmc.pdf" target="_blank" rel="noopener noreferrer">Jean-Michel Campin: MITgcm development <img src="/assets/images/icons/acrobatlogo.gif" class="img--initial" /></a>
+						<a class='detail_link' href="https://drive.google.com/file/d/1FcCKC8EOKZ5H_76cUu_Irkfq7lQjlKSb/view?usp=sharing" target="_blank" rel="noopener noreferrer">Ian Fenty: 2019 ECCO Town Hall as Powerpoint<img src="/assets/images/icons/powerpoint_icon.png" class="img--initial" height="20" width="20" /></a>
+					</li>
+					<li>
+						<a class='detail_link' href="https://drive.google.com/file/d/15luafygxoaKilxsYjkQwv3cZGQy2JU4c/view?usp=sharing" target="_blank" rel="noopener noreferrer">Ian Fenty: 2019 ECCO Town Hall as PDF<img src="/assets/images/icons/acrobatlogo.gif" class="img--initial" /></a>
+					</li>
+				</ul>
+				<br><br>				
+				<h2 class="content_title named-anchor" id="2019SS">2019 ECCO Summer School</h2>
+					<p> List to be completed.  For the time being, <a class='detail_link' href="https://www.eccosummerschool.org/schedule-1" target="_blank" rel="noopener noreferrer">Please visit this page to find links to all presentations and videos</a></p>
+					<br>
+				
+				<br><br>				
+				<h2 class="content_title named-anchor" id="2018FallMtg">2018 AGU Fall Meeting</h2>
+				<ul class="bullet_list">
+					<li>
+						<a class='detail_link' href="https://drive.google.com/file/d/1RYsPR4Nq832JNJNg6al3GkXYEj28C64n/view?usp=sharing" target="_blank" rel="noopener noreferrer">Ian Fenty: 2018 ECCO Town Hall as Powerpoint<img src="/assets/images/icons/powerpoint_icon.png" class="img--initial" height="20" width="20" /></a>
+					</li>
+					<li>
+						<a class='detail_link' href="https://drive.google.com/file/d/1Nc1dDBlhrgOGvwjmkwRKY8krEWdze12B/view?usp=sharing" target="_blank" rel="noopener noreferrer">Ian Fenty: 2018 ECCO Town Hall as PDF<img src="/assets/images/icons/acrobatlogo.gif" class="img--initial" /></a>
+					</li>
+				</ul>				
+				<br><br>
+				<h2 class="content_title named-anchor" id="2018OSMtg">2018 AGU Ocean Sciences Meeting</h2>
+				<ul class="bullet_list">
+					<li>
+						<a class='detail_link' href="https://drive.google.com/file/d/1IJBscHc3vVYYL6uCoZqCUseooTVt81NZ/view?usp=sharing" target="_blank" rel="noopener noreferrer">Ian Fenty and Gael Forget: 2018 ECCO Town Hall as Powerpoint<img src="/assets/images/icons/powerpoint_icon.png" class="img--initial" height="20" width="20" /></a>
+					</li>
+					<li>
+						<a class='detail_link' href="https://drive.google.com/file/d/1hqLBVCZmXg1dwT1CwxD1I4bV7RRhPZzj/view?usp=sharing" target="_blank" rel="noopener noreferrer">Ian Fenty and Gael Forget: 2018 ECCO Town Hall as PDF<img src="/assets/images/icons/acrobatlogo.gif" class="img--initial" /></a>
+					</li>
+					
+				</ul>				
+				<br><br>
+				<h2 class="content_title named-anchor" id="2017ECCOMtg">2017 ECCO Meeting</h2>
+				<h3 class="content_title named-anchor" id="2017ECCOMtg_latest">Latest ECCO Products</h3>
+				<ul class="bullet_list">
+					<li>
+						<a href="https://drive.google.com/open?id=1pMDCzvi4oIOY_8kTg2krtKQMpLUm--gS" target="_blank" rel="noopener noreferrer">Jean-Michel Campin: MITgcm development <img src="/assets/images/icons/acrobatlogo.gif" class="img--initial" /></a>
 					</li>
 					<li>
 						<a href="../pdfs/06_1050_Forget_gf_adj_cloud_201711.pdf" target="_blank" rel="noopener noreferrer">Gael Forget: Adjoint and cloud applications of the ECCO v4 framework <img src="/assets/images/icons/acrobatlogo.gif" class="img--initial" /></a>
@@ -35,7 +77,7 @@ EOF;
 					</li>
 				</ul>
 
-				<h2 class="content_title named-anchor" id="posters">Ocean Circulation</h2>
+				<h3 class="content_title named-anchor" id="2017ECCOMtg_oc">Ocean Circulation</h3>
 				<ul class="bullet_list">
 					<li>
 						<a href="../pdfs/06_1210_Liang_ECCO2017.pdf" target="_blank" rel="noopener noreferrer">Xinfeng Liang: The Global Ocean Vertical Velocities from ECCO Version 4 <img src="/assets/images/icons/acrobatlogo.gif" class="img--initial" /></a>
@@ -64,7 +106,7 @@ EOF;
 				</ul>
 
 					
-				<h2 class="content_title named-anchor" id="posters">ECCO Roadmap</h2>
+				<h3 class="content_title named-anchor" id="2017ECCOMtg_roadmap">ECCO Roadmap</h3>
 				<ul class="bullet_list">	
 					<li>
 						<a href="../pdfs/06_1530_ECCO_Sea_Level_Change_20171107.pdf" target="_blank" rel="noopener noreferrer">Ichiro Fukumori: ECCO Sea Level Change <img src="/assets/images/icons/acrobatlogo.gif" class="img--initial" /></a>
@@ -92,7 +134,7 @@ EOF;
 					</li>
 				</ul>
 
-				<h2 class="content_title named-anchor" id="posters">Coupling with the cryosphere</h2>
+				<h3 class="content_title named-anchor" id="2017ECCOMtg_coupling">Coupling with the cryosphere</h3>
 				<ul class="bullet_list">
 					<li>
 						<a href="../pdfs/07_0850_Carroll_ECCO_2017.pdf" target="_blank" rel="noopener noreferrer">Dustin Carroll: Ice-sheet-ocean interactions in Greenland fjords <img src="/assets/images/icons/acrobatlogo.gif" class="img--initial" /></a>


### PR DESCRIPTION
1. swapped postiion of 'news' tab and 'about' tab on header
1. added pptx and pdf versions of 2019 and 2018 town halls to main page, to news, and to research/presentations
1. updated news/ page to include 2019 town hall and ecco summer school
1. reorganized the research/presentation pages.  added links to the 2019 and 2018 town halls.